### PR TITLE
Add sprite loading with state machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,5 @@ A simple side-scrolling platformer inspired by classic 8-bit games. The project 
 ## Running
 Open `index.html` in a modern browser to start playing.
 
-Placeholder graphics are used for player, enemies, and blocks. Replace images inside the `assets` directory to customize the look of the game.
+Placeholder graphics are used for player, enemies, and blocks. To customize the player look, place the following files inside `assets/player`:
+`player_idle.png`, `player_run.png`, `player_jump.png` and `player_dead.png`.


### PR DESCRIPTION
## Summary
- load player sprites with fallback images
- track player state to pick correct sprite
- start game loop after sprite loading
- document sprite files in README

## Testing
- `node --check game.js`

------
https://chatgpt.com/codex/tasks/task_e_68486302f424832e93bd2e62c462582b