### PR TITLE
Fix player sprite rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ A simple side-scrolling platformer inspired by classic 8-bit games. The project 
 Open `index.html` in a modern browser to start playing.
 
 Placeholder graphics are used for player, enemies, and blocks. To customize the player look, place the following files inside `assets/player`:
-`player_idle.png`, `player_run.png`, `player_jump.png` and `player_dead.png`.
+`player_idle.png`, `player_run1.png`, `player_run2.png`, `player_jump.png`, `player_crouch.png` and `player_dead.png`.

--- a/game.js
+++ b/game.js
@@ -14,21 +14,28 @@ const placeholderSrc = createPlaceholder();
 const placeholderImg = new Image();
 placeholderImg.src = placeholderSrc;
 
-// Sprite paths for the player states
-const spritePaths = {
-    idle: 'assets/player/player_idle.png',
-    run: 'assets/player/player_run.png',
-    jump: 'assets/player/player_jump.png',
-    dead: 'assets/player/player_dead.png'
+// Individual sprite images for the player
+const playerSprites = {
+    idle: new Image(),
+    run1: new Image(),
+    run2: new Image(),
+    jump: new Image(),
+    crouch: new Image(),
+    dead: new Image()
 };
 
-// Loaded Image objects will be stored here
-const sprites = {};
-
 function loadSprites() {
-    const promises = Object.entries(spritePaths).map(([state, path]) => {
-        const img = new Image();
-        sprites[state] = img;
+    const paths = {
+        idle: 'assets/player/player_idle.png',
+        run1: 'assets/player/player_run1.png',
+        run2: 'assets/player/player_run2.png',
+        jump: 'assets/player/player_jump.png',
+        crouch: 'assets/player/player_crouch.png',
+        dead: 'assets/player/player_dead.png'
+    };
+
+    const promises = Object.entries(paths).map(([state, path]) => {
+        const img = playerSprites[state];
         return new Promise(resolve => {
             img.onload = () => resolve();
             img.onerror = () => {
@@ -39,6 +46,7 @@ function loadSprites() {
             img.src = path;
         });
     });
+
     return Promise.all(promises);
 }
 
@@ -225,6 +233,8 @@ window.addEventListener('resize', resizeCanvas);
 
 // Camera offset for scrolling
 let cameraX = 0;
+// Counter used to alternate running animation frames
+let runAnim = 0;
 
 // Input handling
 window.addEventListener('keydown', e => keys[e.key] = true);
@@ -351,9 +361,15 @@ function update() {
 
     // Update player animation state
     if (gameState === 'playing') {
-        if (!player.onGround) playerState = 'jump';
-        else if (Math.abs(player.vx) > 0.2) playerState = 'run';
-        else playerState = 'idle';
+        if (!player.onGround) {
+            playerState = 'jump';
+        } else if (Math.abs(player.vx) > 0.2) {
+            playerState = 'run';
+            runAnim = (runAnim + 1) % 20; // advance run animation counter
+        } else {
+            playerState = 'idle';
+            runAnim = 0;
+        }
     }
 
     // Camera follows player with a bit of smoothing
@@ -407,7 +423,13 @@ function draw() {
     ctx.fillRect(flag.x, flag.y, flag.width, flag.height);
 
     // Draw player using sprite based on state
-    const currentImg = sprites[playerState] ?? placeholderImg;
+    let currentImg;
+    if (playerState === 'run') {
+        currentImg = (runAnim < 10 ? playerSprites.run1 : playerSprites.run2);
+    } else {
+        currentImg = playerSprites[playerState];
+    }
+    if (!currentImg) currentImg = placeholderImg;
     ctx.drawImage(currentImg, player.x, player.y, player.width, player.height);
 
     ctx.restore();


### PR DESCRIPTION
## Summary
- load individual player sprites instead of a spritesheet
- alternate running frame between `run1` and `run2`
- update placeholder instructions in README

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684875092a5c832eb2efdc27b783a84b