### PR TITLE
Fix player scaling and block collision

### DIFF
--- a/game.js
+++ b/game.js
@@ -238,6 +238,8 @@ function rectsCollide(a, b) {
 
 // Main update function
 function update() {
+    // Previous position before applying physics
+    const prevY = player.y;
     // Horizontal movement with basic acceleration
     if (keys['ArrowLeft']) {
         player.vx -= 0.5;
@@ -282,7 +284,7 @@ function update() {
         // landing on top
         if (player.vy > 0 &&
             player.x + player.width > p.x && player.x < p.x + p.width &&
-            player.y + player.height <= p.y && nextY + player.height >= p.y) {
+            prevY + player.height <= p.y && player.y + player.height >= p.y) {
             player.y = p.y - player.height;
             player.vy = 0;
             player.onGround = true;
@@ -290,7 +292,7 @@ function update() {
         // hitting the underside
         if (player.vy < 0 &&
             player.x + player.width > p.x && player.x < p.x + p.width &&
-            player.y >= p.y + p.height && nextY <= p.y + p.height) {
+            prevY >= p.y + p.height && player.y <= p.y + p.height) {
             player.y = p.y + p.height;
             player.vy = 0;
         }
@@ -302,7 +304,7 @@ function update() {
         const overlapX = player.x + player.width > block.x && player.x < block.x + block.width;
         // hit from below to get coin
         if (player.vy < 0 && overlapX &&
-            player.y >= block.y + block.height && nextY <= block.y + block.height) {
+            prevY >= block.y + block.height && player.y <= block.y + block.height) {
             player.y = block.y + block.height;
             player.vy = 0;
             if (!block.used) {
@@ -312,7 +314,7 @@ function update() {
         }
         // land on top
         if (player.vy > 0 && overlapX &&
-            player.y + player.height <= block.y && nextY + player.height >= block.y) {
+            prevY + player.height <= block.y && player.y + player.height >= block.y) {
             player.y = block.y - player.height;
             player.vy = 0;
             player.onGround = true;
@@ -408,7 +410,7 @@ function draw() {
 
     // Draw player using sprite based on state
     const currentImg = sprites[playerState] ?? placeholderImg;
-    ctx.drawImage(currentImg, player.x, player.y, player.width, player.height);
+    ctx.drawImage(currentImg, player.x, player.y, 128, 128);
 
     ctx.restore();
 


### PR DESCRIPTION
## Summary
- draw player sprites at 128x128 so the character appears larger
- keep track of previous vertical position for more reliable collisions
- use previous position for underside checks on platforms and coin blocks

## Testing
- `node --check game.js`
- `node -e "require('./game.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68492f59faf0832e97fc98efceec1d56